### PR TITLE
Created a document cache decorator and handled Relationships as tuple…

### DIFF
--- a/src/spdx_tools/common/typing/dataclass_with_properties.py
+++ b/src/spdx_tools/common/typing/dataclass_with_properties.py
@@ -1,10 +1,14 @@
 # SPDX-FileCopyrightText: 2022 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
+from dataclasses import dataclass, astuple
 
 from beartype import beartype
 from beartype.roar import BeartypeCallHintException
+
+
+def freeze_dataclass_with_properties_list(items):
+    return {astuple(itm) for itm in items}
 
 
 def dataclass_with_properties(cls):

--- a/src/spdx_tools/spdx/model/document.py
+++ b/src/spdx_tools/spdx/model/document.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import field
+from dataclasses import field, astuple
 from datetime import datetime
 
 from beartype.typing import List, Optional
@@ -82,5 +82,17 @@ class Document:
         extracted_licensing_info = [] if extracted_licensing_info is None else extracted_licensing_info
         check_types_and_set_values(self, locals())
 
-    def __hash__(self):
-        return id(self)
+
+def document_cache(func):
+    cache = {}
+
+    def cached_function(document: Document):
+        key = id(document)
+        if key in cache.keys():
+            return cache[key]
+        else:
+            value = func(document)
+            cache[key] = value
+            return value
+    
+    return cached_function

--- a/src/spdx_tools/spdx/model/relationship.py
+++ b/src/spdx_tools/spdx/model/relationship.py
@@ -73,6 +73,3 @@ class Relationship:
         comment: Optional[str] = None,
     ):
         check_types_and_set_values(self, locals())
-
-    def __hash__(self):
-        return hash("{} -> {} ({})".format(self.spdx_element_id, str(self.related_spdx_element_id), str(self.relationship_type)))

--- a/src/spdx_tools/spdx/validation/spdx_id_validators.py
+++ b/src/spdx_tools/spdx/validation/spdx_id_validators.py
@@ -10,6 +10,7 @@ from functools import cache
 
 from spdx_tools.spdx.document_utils import get_contained_spdx_element_ids
 from spdx_tools.spdx.model import Document, File
+from spdx_tools.spdx.model.document import document_cache
 
 
 def is_valid_internal_spdx_id(spdx_id: str) -> bool:
@@ -24,13 +25,13 @@ def is_spdx_id_present_in_files(spdx_id: str, files: List[File]) -> bool:
     return spdx_id in [file.spdx_id for file in files]
 
 
-@cache
+# @cache
 def is_spdx_id_present_in_document(spdx_id: str, document: Document) -> bool:
     all_spdx_ids_in_document: Set[str] = get_set_of_all_spdx_ids(document)
 
     return spdx_id in all_spdx_ids_in_document
 
-@cache
+@document_cache
 def get_set_of_all_spdx_ids(document: Document) -> Set[str]:
     return set(get_list_of_all_spdx_ids(document))
 


### PR DESCRIPTION
Removes __hash__ methods from Document and Relationship to preserve the mutability of these objects.
To preserve the speedup, I created a special cache decorator for Documents and a method for "freezing" a List of Relationships into a set.